### PR TITLE
メッセージ送信機能の非同期通信

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,48 @@
+$(function(){
+  function buildHTML(message){
+    var message_image = message.image ? message.image : ""
+    var html = `<div class="message">
+                  <div class="upper-message">
+                    <div class="upper-message__user--name">
+                       ${message.user_name}
+                    </div>
+                    <div class="upper-message__date">
+                       ${message.datetime}
+                    </div>
+                  </div>
+                  <div class="lower-message">
+                    <p class="lower-message__content">
+                      ${message.content}
+                    </p>
+                    <img class="lower-message__image" src="${message_image}">
+                  </div>
+                </div>`
+    return html;
+  }
+
+  $('.new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+     $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data) {
+      var html = buildHTML(data);
+      $('.messages').append(html);
+      $('.form__message, .form__mask__image').val('');
+      $('.chat-body').animate({scrollTop: $('.chat-body').get(0).scrollHeight}, 'slow');
+    })
+    .fail(function() {
+      alert('error');
+    })
+    .always(function(){
+      $('.form__submit').prop("disabled", false);
+    });
+  });
+});

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました' }
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,6 @@
+# binding.pry
+json.user_name    @message.user.name
+json.content      @message.content
+json.image        @message.image.url
+json.datetime     @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.id           @message.id

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -17,7 +17,7 @@
     .messages
       = render @messages
     .form
-      = form_for [@group, @message] do |f|
+      = form_for [@group, @message] , html: { class: 'new_message'} do |f|
         = f.text_field :content, class: 'form__message', placeholder: 'type a message'
         .form__mask
           = f.label :image, class: 'form__mask__image' do

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
# What
非同期でメッセージを送信できる機能を作成

# Why
UXをあげるため

# capture
https://gyazo.com/e7223ef7d7dc6903bd1d2ac37a60595a

# how
1,新しいブランチを作成する
2,jsファイルを作成する
3,フォームが送信されたら、イベントが発火するようにする
4,2のイベントが発火したときにAjaxを使用して、messages#createが動くようにする
5,messages#createでメッセージを保存し、respond_toを使用してHTMLとJSONの場合で処理を分ける
6,jbuilderを使用して、作成したメッセージをJSON形式で返す
7.返ってきたJSONをdoneメソッドで受取り、HTMLを作成する
8,6で作成したHTMLをメッセージ画面の一番下に追加する
9,HTMLを追加した分、メッセージ画面を下にスクロールする
10,非同期に失敗した場合の処理も準備する